### PR TITLE
11 bcrypt and jwt utility

### DIFF
--- a/server/infrastructure/prisma/schema.prisma
+++ b/server/infrastructure/prisma/schema.prisma
@@ -30,7 +30,7 @@ model User {
   resetCode String?
   resetCodeExpiry DateTime?
  
-  tasks Task[]
+  calendarItems CalendarItem[]
   notifications Notification[]
 
   createdAt DateTime @default(now())
@@ -39,7 +39,7 @@ model User {
   @@index([resetCode])
 }
 
-model Task {
+model CalendarItem {
   id String @id @default(uuid())
   userId String 
 
@@ -48,6 +48,7 @@ model Task {
   startTime DateTime
   endTime DateTime
   isAllDay Boolean
+  isHiglighted Boolean
   status Status
 
   user User @relation(fields: [userId], references: [id])

--- a/server/utils/auth/bcrypt.ts
+++ b/server/utils/auth/bcrypt.ts
@@ -1,0 +1,16 @@
+import bcrypt from "bcryptjs";
+
+export const toHashPassword = async (password: string): Promise<string> => {
+  const cryptSalt = await bcrypt.genSalt(10);
+  const hashedPassword = await bcrypt.hash(password, cryptSalt);
+
+  return hashedPassword;
+};
+
+export const validatePassword = async (
+  password: string,
+  storedPassword: string
+) => {
+  const isPasswordMatched = await bcrypt.compare(password, storedPassword);
+  return isPasswordMatched;
+};

--- a/server/utils/auth/jwt.ts
+++ b/server/utils/auth/jwt.ts
@@ -1,0 +1,21 @@
+import { Request, Response } from "express";
+import jwt from "jsonwebtoken";
+
+export const generateTokenAndSetCookie = (
+  userId: string,
+  req: Request,
+  res: Response
+) => {
+  const userAgent = req.headers["user-agent"] || "";
+  const isSafari = /Safari/.test(userAgent) && !/Chrome/.test(userAgent);
+
+  const token = jwt.sign({ userId }, process.env.JWT_SECRET as string, {
+    expiresIn: "5h",
+  });
+  res.cookie("jwt", token, {
+    maxAge: 5 * 60 * 60 * 1000,
+    httpOnly: true,
+    sameSite: isSafari ? undefined : "strict",
+    secure: isSafari ? false : process.env.NODE_ENV !== "development",
+  });
+};


### PR DESCRIPTION

**Utility Functions**
- Bcrypt utility functions to hash password (for sign up endpoint) & validate password w/ hashed (to be used at sign in endpoint)
- JWT utility functions to generate the token and set the session cookies

**Additional** commit includes update on` Prisma Schema`
- changed "Task" to "CalendarItem"
- added field:  isHighlighted `boolean` at the CalendarItem schema
 
