### PR TITLE
40 feature validate otp signup endpoint

### DIFF
--- a/server/internal/auth/controller.ts
+++ b/server/internal/auth/controller.ts
@@ -11,6 +11,7 @@ export class AuthController {
     this.signOut = this.signOut.bind(this);
     this.oAuthSignUp = this.oAuthSignUp.bind(this);
     this.oAuthSignIn = this.oAuthSignIn.bind(this);
+    this.verifySignUp = this.verifySignUp.bind(this);
   }
 
   async signUp(req: Request, res: Response, next: NextFunction) {
@@ -103,6 +104,25 @@ export class AuthController {
       generateTokenAndSetCookie(userResData.id, req, res);
       res.status(200).json({
         message: "You have successfully signed in",
+        user: userResData,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async verifySignUp(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { key, otp } = req.body;
+
+      if (!key || !otp) {
+        throw new ValidationError("Redis key and OTP is required");
+      }
+
+      const userResData = await this.authService.verifyOtpSignUp(key, otp);
+
+      res.status(200).json({
+        message: "You have successfully signed up",
         user: userResData,
       });
     } catch (error) {

--- a/server/internal/auth/controller.ts
+++ b/server/internal/auth/controller.ts
@@ -65,18 +65,18 @@ export class AuthController {
         throw new ValidationError("Access Token is required");
       }
 
-      const userResData = await this.authService.oAuthSignUp(
+      const redisKey = await this.authService.oAuthSignUp(
         provider,
         accessToken
       );
-      if (!userResData) {
+      if (!redisKey) {
         throw new Error("Failed to perform OAuth protocol");
       }
 
-      generateTokenAndSetCookie(userResData.id, req, res);
       res.status(200).json({
-        message: "You have successfully signed in",
-        user: userResData,
+        message:
+          "Verification code was sent to your email. Please confirm to continue.",
+        key: redisKey,
       });
     } catch (error) {
       next(error);

--- a/server/internal/auth/route.ts
+++ b/server/internal/auth/route.ts
@@ -8,5 +8,6 @@ router.post("/signin", authController.signIn);
 router.post("/oauth-signup/:provider", authController.oAuthSignUp);
 router.post("/oauth-signin/:provider", authController.oAuthSignIn);
 router.post("/signout", authController.signOut);
+router.post("/verify-otp", authController.verifySignUp);
 
 export default router;

--- a/server/internal/auth/service.ts
+++ b/server/internal/auth/service.ts
@@ -14,7 +14,7 @@ import {
   handleGithubProvider,
   handleGoogleProvider,
 } from "@/utils/auth/oauth";
-import { retrieveRedisData } from "@/utils/otp/redisStore";
+import { deleteStoredData, retrieveRedisData } from "@/utils/otp/redisStore";
 import { sendOtpToEmail } from "@/utils/otp/sendOTP";
 
 interface UserData {
@@ -164,6 +164,12 @@ export class AuthService {
     }
 
     const createdUser = await this.authRepository.createUser(user);
+    if (!createdUser) {
+      throw new Error("Failed to store the user data in the database");
+    }
+
+    await deleteStoredData(key);
+
     return {
       id: createdUser.id,
       username: createdUser.username,

--- a/server/internal/auth/service.ts
+++ b/server/internal/auth/service.ts
@@ -12,7 +12,7 @@ import { toHashPassword, validatePassword } from "@/utils/auth/bcrypt";
 import { verifyToken } from "@/utils/auth/jwt";
 import {
   UserInfo,
-  handleFacebookProvider,
+  handleGithubProvider,
   handleGoogleProvider,
 } from "@/utils/auth/oauth";
 import { sendOtpToEmail } from "@/utils/otp/sendOTP";
@@ -101,8 +101,8 @@ export class AuthService {
         userInfo = await handleGoogleProvider(accessToken);
         break;
 
-      case "facebook":
-        userInfo = await handleFacebookProvider(accessToken);
+      case "github":
+        userInfo = await handleGithubProvider(accessToken);
         break;
 
       default:
@@ -137,8 +137,8 @@ export class AuthService {
         case "google":
           userInfo = await handleGoogleProvider(accessToken);
           break;
-        case "facebook":
-          userInfo = await handleFacebookProvider(accessToken);
+        case "github":
+          userInfo = await handleGithubProvider(accessToken);
           break;
         default:
           throw new ValidationError(`Unsupported provider: ${provider}`);

--- a/server/utils/auth/oauth.ts
+++ b/server/utils/auth/oauth.ts
@@ -26,21 +26,17 @@ const handleGithubProvider = async (
   accessToken: string
 ): Promise<UserInfo<string>> => {
   try {
-    // Get basic user profile
     const { data: user } = await axios.get("https://api.github.com/user", {
       headers: {
         Authorization: `Bearer ${accessToken}`,
-        Accept: "application/vnd.github+json",
       },
     });
 
-    // Get user emails (primary + verified)
     const { data: emails } = await axios.get(
       "https://api.github.com/user/emails",
       {
         headers: {
           Authorization: `Bearer ${accessToken}`,
-          Accept: "application/vnd.github+json",
         },
       }
     );

--- a/server/utils/auth/oauth.ts
+++ b/server/utils/auth/oauth.ts
@@ -22,20 +22,39 @@ const handleGoogleProvider = async (
   }
 };
 
-const handleFacebookProvider = async (
+const handleGithubProvider = async (
   accessToken: string
 ): Promise<UserInfo<string>> => {
   try {
-    const facebookUrl = `https://graph.facebook.com/me?fields=id,name,email,picture.type(large)&access_token=${accessToken}`;
-    const { data } = await axios.get(facebookUrl);
+    // Get basic user profile
+    const { data: user } = await axios.get("https://api.github.com/user", {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: "application/vnd.github+json",
+      },
+    });
+
+    // Get user emails (primary + verified)
+    const { data: emails } = await axios.get(
+      "https://api.github.com/user/emails",
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          Accept: "application/vnd.github+json",
+        },
+      }
+    );
+
+    const primaryEmail = emails.find((email: any) => email.primary)?.email;
+
     return {
-      email: data.email,
-      username: data.name,
-      profilePic: data.picture?.data?.url,
+      email: primaryEmail || "",
+      username: user.login,
+      profilePic: user.avatar_url,
     };
   } catch (error) {
-    throw new Error("Failed to handle facebook access token ");
+    throw new Error("Failed to handle GitHub access token");
   }
 };
 
-export { handleFacebookProvider, handleGoogleProvider };
+export { handleGithubProvider, handleGoogleProvider };

--- a/server/utils/email/nodemailer.ts
+++ b/server/utils/email/nodemailer.ts
@@ -6,7 +6,7 @@ import {
 
 import { generateOTP } from "@/utils/otp/generateOtp";
 
-export const generateVerificationCode = async (
+export const generateAndSendVerificationCode = async (
   email: string,
   feature: "password-reset" | "oauth"
 ) => {

--- a/server/utils/otp/generateOtp.ts
+++ b/server/utils/otp/generateOtp.ts
@@ -6,8 +6,7 @@ interface GeneratedCodeProps {
 export const generateOTP = (): GeneratedCodeProps => {
   const otp = Math.floor(10000 + Math.random() * 90000).toString();
 
-  const expiryDate = new Date(Date.now() + 5 * 60 * 1000);
-  const expiry = Math.floor(expiryDate.getTime() / 1000);
+  const expiry = 300;
 
   return { otp, expiry };
 };

--- a/server/utils/otp/redisStore.ts
+++ b/server/utils/otp/redisStore.ts
@@ -1,10 +1,10 @@
 import { redisClient } from "@/infrastructure/database/connectToRedis";
-import { SignUpData } from "@/internal/auth/dto";
+import { OAuthData, SignUpData } from "@/internal/auth/dto";
 
 import { v4 as uuidv4 } from "uuid";
 
 export const storeTemporaryUser = async (
-  tempUser: SignUpData,
+  tempUser: SignUpData | OAuthData,
   otp: string,
   expiry: number = 300
 ): Promise<string> => {

--- a/server/utils/otp/redisStore.ts
+++ b/server/utils/otp/redisStore.ts
@@ -20,3 +20,17 @@ export const storeTemporaryUser = async (
     throw new Error("Failed to store the temporary user data at Redis Storage");
   }
 };
+
+export const retrieveRedisData = async (key: string) => {
+  try {
+    if (!redisClient) throw new Error("Redis client not initialized");
+    const data = await redisClient.get(key);
+    if (!data) return null;
+
+    const { user, otp: storedOtp } = JSON.parse(data);
+
+    return { user, storedOtp };
+  } catch (error) {
+    throw new Error("Failed to get the stored redis data");
+  }
+};

--- a/server/utils/otp/redisStore.ts
+++ b/server/utils/otp/redisStore.ts
@@ -34,3 +34,15 @@ export const retrieveRedisData = async (key: string) => {
     throw new Error("Failed to get the stored redis data");
   }
 };
+
+export const deleteStoredData = async (key: string) => {
+  try {
+    if (!redisClient) throw new Error("Redis client not initialized");
+
+    await redisClient.del(key);
+
+    return;
+  } catch (error) {
+    throw new Error("Failed to get the delete the stored redis data");
+  }
+};

--- a/server/utils/otp/sendOTP.ts
+++ b/server/utils/otp/sendOTP.ts
@@ -1,0 +1,22 @@
+import { ValidationError } from "@/infrastructure/errors/customErrors";
+import { OAuthData, SignUpData } from "@/internal/auth/dto";
+
+import { generateAndSendVerificationCode } from "@/utils/email/nodemailer";
+import { storeTemporaryUser } from "@/utils/otp/redisStore";
+
+export const sendOtpToEmail = async (
+  email: string,
+  validUser: SignUpData | OAuthData
+) => {
+  try {
+    const { otp, expiry } = await generateAndSendVerificationCode(
+      email,
+      "oauth"
+    );
+    const tempKey = await storeTemporaryUser(validUser, otp, expiry);
+    return tempKey;
+  } catch (error) {
+    console.log(error);
+    throw new ValidationError("Failed to process the sign up");
+  }
+};


### PR DESCRIPTION
- Replaced Facebook OAuth integration with GitHub OAuth
- Updated service and utility functions to use GitHub endpoints and data structure
- Adjusted provider handling logic for sign up and sign in flows
- Validates OTP from Redis, creates user in the database on success, and returns user data.
- Improved error handling for expired/invalid OTP and duplicate accounts
- Added logic to delete temporary user/OTP data from Redis after successful verification and user creation
- Ensures data hygiene and security by removing sensitive temporary data post-verification