### PR TITLE
🌐 api: delete user endpoint

### DIFF
--- a/server/internal/user/controller.ts
+++ b/server/internal/user/controller.ts
@@ -1,3 +1,4 @@
+import { CustomRequest } from "@/infrastructure/middleware/interface";
 import { UserService } from "@/internal/user/service";
 import { NextFunction, Request, Response } from "express";
 export class UserController {
@@ -51,8 +52,19 @@ export class UserController {
     }
   }
 
-  async deleteUser(req: Request, res: Response, next: NextFunction) {
+  async deleteUser(req: CustomRequest, res: Response, next: NextFunction) {
     try {
+      const userId = req.params.id;
+      const authUserId = req.user?.id!;
+
+      const username = req.query.username;
+      const usernameStr = String(username);
+
+      await this.userService.deleteUser(userId, authUserId, usernameStr);
+
+      res
+        .status(200)
+        .json({ message: "You have deleted your account successfully" });
     } catch (error) {
       next(error);
     }

--- a/server/internal/user/repository.ts
+++ b/server/internal/user/repository.ts
@@ -57,8 +57,19 @@ export class UserRepository implements IUserRepository {
       throw error;
     }
   }
-  deleteUser(userId: string): Promise<void> {
-    throw new Error("Method not implemented.");
+
+  async deleteUser(userId: string): Promise<void> {
+    try {
+      await prisma.user.delete({
+        where: { id: userId },
+      });
+    } catch (error) {
+      if (error instanceof PrismaClientKnownRequestError) {
+        console.error(error.message);
+        throw new DatabaseError("Database error at deleteUser method");
+      }
+      throw error;
+    }
   }
   async findUser(
     field: "email" | "username",

--- a/server/internal/user/route.ts
+++ b/server/internal/user/route.ts
@@ -15,7 +15,7 @@ router.put(
   upload.single("profilePic"),
   userController.updateUserProfilePic
 );
-router.delete("/delete", userController.deleteUser);
+router.delete("/delete/:id", userController.deleteUser);
 router.get("/", userController.getAllUsers);
 
 export default router;


### PR DESCRIPTION
✨ **Delete User Endpoint**

**Description**

- Implemented the DELETE /user/delete/:id endpoint to allow authenticated users to delete their own accounts
- Added authorization check to ensure users can only delete their own account
- Validates username via query parameter to prevent accidental or malicious deletions
- Removes the user's profile picture from Cloudinary if it is not the default image
-Handles errors for missing user, mismatched username, and authorization failures
- Updated repository with a robust deleteUser method using Prisma and improved error handling

🧪 **Tested**

- Verified user can delete their own account and profile picture is removed if custom
- Confirmed proper error responses for unauthorized, invalid, or non-existent users
