### PR TITLE
64 feature create calendaritem endpoint

### DIFF
--- a/server/infrastructure/prisma/schema.prisma
+++ b/server/infrastructure/prisma/schema.prisma
@@ -45,7 +45,7 @@ model User {
 
 model CalendarItem {
   id String @id @default(uuid())
-  userId String @unique
+  userId String 
 
   title String
   description String?

--- a/server/internal/calendaritem/controller.ts
+++ b/server/internal/calendaritem/controller.ts
@@ -1,3 +1,4 @@
+import { CustomRequest } from "@/infrastructure/middleware/interface";
 import { CalendarService } from "@/internal/calendaritem/service";
 import { NextFunction, Request, Response } from "express";
 export class CalendarController {
@@ -8,9 +9,25 @@ export class CalendarController {
     this.deleteCalendarItem = this.deleteCalendarItem.bind(this);
   }
 
-  async createCalendarItem(req: Request, res: Response, next: NextFunction) {
+  async createCalendarItem(
+    req: CustomRequest,
+    res: Response,
+    next: NextFunction
+  ) {
     try {
-      res.status(200).json("Create Calendar Item Endpoint");
+      const userId = req.user?.id!;
+
+      const calendarItem = req.body;
+
+      const createdItem = await this.calendarService.createCalendarItem({
+        userId,
+        calendarItem,
+      });
+
+      res.status(201).json({
+        message: "You have successfully added a calendar event",
+        calendarItem: createdItem,
+      });
     } catch (error) {
       next(error);
     }

--- a/server/internal/calendaritem/dto.ts
+++ b/server/internal/calendaritem/dto.ts
@@ -1,21 +1,16 @@
-enum Status {
-  PENDING,
-  INCOMING,
-  INPROGRESS,
-  COMPLETED,
-}
+export type Status = "PENDING" | "INCOMING" | "INPROGRESS" | "COMPLETED";
 
-export class CalendarItem {
-  id!: string;
-  userId!: string;
-
-  title!: string;
-  description?: string;
-  startTIme!: Date;
-  endTime!: Date;
-  isAllDay!: boolean;
-  isRecurrent!: boolean;
-  recurrenceRule!: string;
-  isHighlighted!: boolean;
-  status!: Status;
+export interface CalendarItem {
+  id: string;
+  title: string;
+  description?: string | null;
+  startTime: Date;
+  endTime: Date;
+  isAllDay: boolean;
+  isRecurrent: boolean;
+  recurrenceRule?: string | null;
+  isHighlighted: boolean;
+  status: Status;
+  createdAt: Date;
+  updatedAt: Date;
 }

--- a/server/internal/calendaritem/interface.ts
+++ b/server/internal/calendaritem/interface.ts
@@ -14,6 +14,8 @@ export interface ICalendarItemRepository {
   }: MutateCalendarItemRequest): Promise<CalendarItem>;
 
   deleteCalendarItem(userId: string): Promise<void>;
+
+  createNotification(userId: string, message: string): Promise<void>;
 }
 
 export interface MutateCalendarItemRequest {

--- a/server/internal/calendaritem/interface.ts
+++ b/server/internal/calendaritem/interface.ts
@@ -18,5 +18,5 @@ export interface ICalendarItemRepository {
 
 export interface MutateCalendarItemRequest {
   userId: string;
-  calendarItem: Partial<CalendarItem>;
+  calendarItem: Omit<CalendarItem, "id" | "createdAt" | "updatedAt">;
 }

--- a/server/internal/calendaritem/repository.ts
+++ b/server/internal/calendaritem/repository.ts
@@ -1,15 +1,32 @@
+import { prisma } from "@/infrastructure/database/connectToDb";
+import { DatabaseError } from "@/infrastructure/errors/customErrors";
 import { CalendarItem } from "@/internal/calendaritem/dto";
 import {
   ICalendarItemRepository,
   MutateCalendarItemRequest,
 } from "@/internal/calendaritem/interface";
+import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
 
 export class CalendarRepository implements ICalendarItemRepository {
-  createCalendarItem({
+  async createCalendarItem({
     userId,
     calendarItem,
   }: MutateCalendarItemRequest): Promise<CalendarItem> {
-    throw new Error("Method not implemented.");
+    try {
+      const calendar = await prisma.calendarItem.create({
+        data: {
+          userId,
+          ...calendarItem,
+        },
+      });
+      return calendar;
+    } catch (error) {
+      if (error instanceof PrismaClientKnownRequestError) {
+        console.error(error.message);
+        throw new DatabaseError("Database error at createCalendarItem method");
+      }
+      throw error;
+    }
   }
   getCalendarItemsByUser(userId: string): Promise<CalendarItem[]> {
     throw new Error("Method not implemented.");

--- a/server/internal/calendaritem/repository.ts
+++ b/server/internal/calendaritem/repository.ts
@@ -40,4 +40,22 @@ export class CalendarRepository implements ICalendarItemRepository {
   deleteCalendarItem(userId: string): Promise<void> {
     throw new Error("Method not implemented.");
   }
+
+  async createNotification(userId: string, message: string): Promise<void> {
+    try {
+      await prisma.notification.create({
+        data: {
+          userId,
+          message,
+          createdAt: new Date(),
+        },
+      });
+    } catch (error) {
+      if (error instanceof PrismaClientKnownRequestError) {
+        console.error(error.message);
+        throw new DatabaseError("Database error at createNotification method");
+      }
+      throw error;
+    }
+  }
 }

--- a/server/internal/calendaritem/route.ts
+++ b/server/internal/calendaritem/route.ts
@@ -1,6 +1,6 @@
 import { protectRoute } from "@/internal/auth/config";
 import { calendarController } from "@/internal/calendaritem/config";
-import express from "Express";
+import express from "express";
 
 const router = express.Router();
 

--- a/server/internal/calendaritem/service.ts
+++ b/server/internal/calendaritem/service.ts
@@ -1,9 +1,67 @@
+import {
+  NotFoundError,
+  ValidationError,
+} from "@/infrastructure/errors/customErrors";
+import { MutateCalendarItemRequest } from "@/internal/calendaritem/interface";
 import { CalendarRepository } from "@/internal/calendaritem/repository";
-
 export class CalendarService {
   constructor(private readonly calendarRepository: CalendarRepository) {}
 
-  async createCalendarItem() {}
+  async createCalendarItem({
+    userId,
+    calendarItem,
+  }: MutateCalendarItemRequest) {
+    const {
+      title,
+      description,
+      startTime,
+      endTime,
+      isAllDay,
+      isRecurrent,
+      recurrenceRule,
+      isHighlighted,
+      status,
+    } = calendarItem;
+
+    if (!userId) throw new NotFoundError("User not found");
+
+    if (!title || typeof title !== "string")
+      throw new ValidationError("Title is required");
+
+    if (!startTime) throw new ValidationError("Invalid start time");
+
+    if (!endTime) throw new ValidationError("Invalid end time");
+
+    if (typeof isAllDay !== "boolean")
+      throw new ValidationError("isAllDay must be boolean");
+
+    if (typeof isRecurrent !== "boolean")
+      throw new ValidationError("isRecurrent must be boolean");
+
+    if (typeof isHighlighted !== "boolean")
+      throw new ValidationError("isHighlighted must be boolean");
+
+    const allowedStatus = ["PENDING", "INCOMING", "INPROGRESS", "COMPLETED"];
+    if (!allowedStatus.includes(status))
+      throw new ValidationError("Invalid status value");
+
+    const createdItem = await this.calendarRepository.createCalendarItem({
+      userId,
+      calendarItem: {
+        title,
+        description,
+        startTime: new Date(startTime),
+        endTime: new Date(endTime),
+        isAllDay,
+        isRecurrent,
+        recurrenceRule,
+        isHighlighted,
+        status,
+      },
+    });
+
+    return createdItem;
+  }
 
   async getCalendarItemsByUser() {}
 

--- a/server/internal/calendaritem/service.ts
+++ b/server/internal/calendaritem/service.ts
@@ -60,6 +60,9 @@ export class CalendarService {
       },
     });
 
+    const notifMessage = `You have created an event: ${title}`;
+    await this.calendarRepository.createNotification(userId, notifMessage);
+
     return createdItem;
   }
 


### PR DESCRIPTION
✨ **Feature: CreateCalendarItem Endpoint**

**Description**

- Implemented the `createCalendarItem` endpoint with full validation for all required fields
- Refactored DTOs and interfaces for calendar items to use string union types and allow nullable fields
- Removed the unique constraint on `userId` in the Prisma schema to allow multiple calendar items per user
- Added a `createNotification` method to the repository to generate a notification message whenever a calendar item is created
- Integrated notification creation into the service layer after successful calendar item creation
- Improved error handling and response structure for calendar item creation

🧪 **Tested**
- Verified calendar items can be created for a user with valid request bodies
- Confirmed notifications are generated and stored after calendar item creation
- Checked validation errors for missing or invalid fields and ensured proper error responses