### PR TITLE
97 notification read and mark all read

### DIFF
--- a/server/internal/notification/controller.ts
+++ b/server/internal/notification/controller.ts
@@ -1,6 +1,6 @@
 import { CustomRequest } from "@/infrastructure/middleware/interface";
 import { NotificationService } from "@/internal/notification/service";
-import { NextFunction, Request, Response } from "express";
+import { NextFunction, Response } from "express";
 0;
 
 export class NotificationController {
@@ -33,20 +33,31 @@ export class NotificationController {
   }
 
   async markNotificationAsRead(
-    req: Request,
+    req: CustomRequest,
     res: Response,
     next: NextFunction
   ) {
-    res.status(200).json({ message: "Mark Notification As Read" });
-  }
+    try {
+      const notifId = req.params.id;
 
+      await this.notificationService.markNotificationAsRead(notifId);
+
+      res.status(200).json({ message: "A notification was marked as read" });
+    } catch (error) {
+      next(error);
+    }
+  }
   async markAllNotificationsAsRead(
-    req: Request,
+    req: CustomRequest,
     res: Response,
     next: NextFunction
   ) {
-    res
-      .status(200)
-      .json({ message: "Mark All Notifications As Read Endpoint" });
+    try {
+      if (!req.user) {
+        return next(new Error("User not authenticated"));
+      }
+    } catch (error) {
+      next(error);
+    }
   }
 }

--- a/server/internal/notification/controller.ts
+++ b/server/internal/notification/controller.ts
@@ -56,6 +56,18 @@ export class NotificationController {
       if (!req.user) {
         return next(new Error("User not authenticated"));
       }
+
+      const userId = req.user.id;
+
+      const isReadCount =
+        await this.notificationService.markAllNotificationsAsRead(userId);
+
+      res
+        .status(200)
+        .json({
+          message: "All user notifications were marked as read",
+          isReadCount,
+        });
     } catch (error) {
       next(error);
     }

--- a/server/internal/notification/interface.ts
+++ b/server/internal/notification/interface.ts
@@ -3,5 +3,5 @@ import { Notification } from "@/internal/notification/dto";
 export interface INotificationRepository {
   getUserNotifications(userId: string): Promise<Notification[]>;
   markNotificationAsRead(notifId: string): Promise<Notification>;
-  markAllNotificationsAsRead(userId: string): Promise<void>;
+  markAllNotificationsAsRead(userId: string): Promise<number>;
 }

--- a/server/internal/notification/interface.ts
+++ b/server/internal/notification/interface.ts
@@ -2,6 +2,6 @@ import { Notification } from "@/internal/notification/dto";
 
 export interface INotificationRepository {
   getUserNotifications(userId: string): Promise<Notification[]>;
-  markNotificationAsRead(notifId: string): Promise<void>;
+  markNotificationAsRead(notifId: string): Promise<Notification>;
   markAllNotificationsAsRead(userId: string): Promise<void>;
 }

--- a/server/internal/notification/repository.ts
+++ b/server/internal/notification/repository.ts
@@ -40,7 +40,22 @@ export class NotificationRepository implements INotificationRepository {
       throw error;
     }
   }
-  markAllNotificationsAsRead(userId: string): Promise<void> {
-    throw new Error("Method not implemented.");
+  async markAllNotificationsAsRead(userId: string): Promise<number> {
+    try {
+      const { count } = await prisma.notification.updateMany({
+        where: { userId, isRead: false },
+        data: { isRead: true },
+      });
+
+      return count;
+    } catch (error) {
+      if (error instanceof PrismaClientKnownRequestError) {
+        console.error(error.message);
+        throw new DatabaseError(
+          "Database error at markAllNotificationsAsRead method"
+        );
+      }
+      throw error;
+    }
   }
 }

--- a/server/internal/notification/repository.ts
+++ b/server/internal/notification/repository.ts
@@ -22,8 +22,23 @@ export class NotificationRepository implements INotificationRepository {
       throw error;
     }
   }
-  markNotificationAsRead(notifId: string): Promise<void> {
-    throw new Error("Method not implemented.");
+  async markNotificationAsRead(notifId: string): Promise<Notification> {
+    try {
+      const notification = await prisma.notification.update({
+        where: { id: notifId },
+        data: { isRead: true },
+      });
+
+      return notification;
+    } catch (error) {
+      if (error instanceof PrismaClientKnownRequestError) {
+        console.error(error.message);
+        throw new DatabaseError(
+          "Database error at markNotificationAsRead method"
+        );
+      }
+      throw error;
+    }
   }
   markAllNotificationsAsRead(userId: string): Promise<void> {
     throw new Error("Method not implemented.");

--- a/server/internal/notification/service.ts
+++ b/server/internal/notification/service.ts
@@ -1,4 +1,7 @@
-import { NotFoundError } from "@/infrastructure/errors/customErrors";
+import {
+  NotFoundError,
+  ValidationError,
+} from "@/infrastructure/errors/customErrors";
 import { NotificationRepository } from "@/internal/notification/repository";
 
 export class NotificationService {
@@ -20,7 +23,21 @@ export class NotificationService {
     return notifications;
   }
 
-  async markNotificationAsRead(notifId: string) {}
+  async markNotificationAsRead(notifId: string) {
+    if (!notifId) {
+      throw new NotFoundError("Notification ID");
+    }
+
+    const notification =
+      await this.notificationRepository.markNotificationAsRead(notifId);
+    if (!notification) {
+      throw new ValidationError("Failed to update the notification");
+    }
+
+    if (notification.isRead !== true) {
+      throw new ValidationError("Failed to mark notification as read");
+    }
+  }
 
   async markAllNotificationsAsRead(userId: string) {}
 }

--- a/server/internal/notification/service.ts
+++ b/server/internal/notification/service.ts
@@ -39,5 +39,14 @@ export class NotificationService {
     }
   }
 
-  async markAllNotificationsAsRead(userId: string) {}
+  async markAllNotificationsAsRead(userId: string) {
+    if (!userId) {
+      throw new ValidationError("User ID");
+    }
+
+    const isReadCount =
+      await this.notificationRepository.markAllNotificationsAsRead(userId);
+
+    return isReadCount;
+  }
 }


### PR DESCRIPTION
✨ **Notifications As Read Endpoints**

**Description**

- Implemented an individual notification markAsRead (using notifId as params) endpoint
-  Implemented that all user notifications can be markedAsRead (returns the updated counts of notification)



🧪 **Tested**

- PUT requests were tested for successful change of  isRead field individually and all notification by user
- Validations were also tested to trigger on missing parameters and user id
